### PR TITLE
Remove metadata generation from stream functions

### DIFF
--- a/src/cartobj.rs
+++ b/src/cartobj.rs
@@ -1,6 +1,5 @@
 use crate::globals;
 
-use serde::{Serialize, Deserialize};
 use crypto::symmetriccipher::SynchronousStreamCipher;
 use crypto::rc4::Rc4;
 use libflate::zlib::{Encoder, EncodeOptions, Decoder};
@@ -8,7 +7,7 @@ use std::io::{self, Read, Seek, SeekFrom};
 use json::JsonValue;
 use std::str;
 
-#[derive(Serialize, Deserialize)]
+
 pub struct CartObject {
     header: CartHeader,
     footer: CartFooter,
@@ -16,8 +15,8 @@ pub struct CartObject {
 }
 
 impl CartObject {
-    pub fn new(binary: Vec<u8>, arc4_key: Option<Vec<u8>>, opt_header: Option<String>,
-    opt_footer: Option<String>, version: Option<i16>) -> Result<CartObject, Box<dyn std::error::Error>>{
+    pub fn new(binary: Vec<u8>, arc4_key: Option<Vec<u8>>, opt_header: Option<JsonValue>,
+    opt_footer: Option<JsonValue>, version: Option<i16>) -> Result<CartObject, Box<dyn std::error::Error>>{
         let arc4_key = arc4_key.unwrap_or(globals::DEFAULT_ARC4_KEY.to_vec());
 
         let options = EncodeOptions::new().fixed_huffman_codes();
@@ -26,7 +25,7 @@ impl CartObject {
         let deflated = encoder.finish().into_result()?;
 
         let header = CartHeader::new(arc4_key, opt_header, version);
-        let footer = CartFooter::new(opt_footer, 38 + header.opt_header.len() + deflated.len());
+        let footer = CartFooter::new(opt_footer, 38 + header.opt_header.dump().len() + deflated.len());
 
         Ok(CartObject{header, footer, binary: deflated})
     }
@@ -79,8 +78,8 @@ impl CartObject {
     }
 
     pub fn metadata(&self) -> Result<JsonValue, Box<dyn std::error::Error>>{
-        let mut metadata = json::parse(&self.header.opt_header)?;
-        let extra_metadata = json::parse(&self.footer.opt_footer)?;
+        let mut metadata = self.header.opt_header.clone();
+        let extra_metadata = &self.footer.opt_footer;
 
         for (k, v) in extra_metadata.entries() {
             metadata.insert(k, v.as_str())?;
@@ -89,19 +88,18 @@ impl CartObject {
     }
 }
 
-#[derive(Serialize, Deserialize)]
 struct CartHeader {
     magic: String,
     version: i16,
     arc4_key: Vec<u8>,
-    opt_header: String,
+    opt_header: JsonValue,
 }
 
 impl CartHeader {
-    fn new(arc4_key: Vec<u8>, opt_header: Option<String>, version: Option<i16>) -> CartHeader {
+    fn new(arc4_key: Vec<u8>, opt_header: Option<JsonValue>, version: Option<i16>) -> CartHeader {
         let magic = String::from(globals::CART_MAGIC);
         let version = version.unwrap_or(globals::DEFAULT_VERSION);
-        let opt_header = opt_header.unwrap_or(String::from(""));
+        let opt_header = opt_header.unwrap_or(JsonValue::Null);
 
         CartHeader{magic, version, arc4_key, opt_header}
     }
@@ -138,14 +136,14 @@ impl CartHeader {
         let mut cipher = Rc4::new(&arc4_key);
         let mut plain_text: Vec<u8> = vec![0; opt_header_len as usize];
         cipher.process(&buffer, &mut plain_text[..]);
-        let opt_header = str::from_utf8(&plain_text)?.to_string();
+        let opt_header = json::parse(&str::from_utf8(&plain_text)?.to_string())?;
 
         Ok(CartHeader{magic, version, arc4_key, opt_header})
     }
 
     fn pack(&self) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         let mut packed_header: Vec<u8> = Vec::new();
-        let opt_header_len = self.opt_header.len();
+        let opt_header_str = self.opt_header.dump();
 
         // Pack mandatory header
         packed_header.extend(self.magic.as_bytes());
@@ -156,30 +154,26 @@ impl CartHeader {
         } else {
             packed_header.extend(bincode::serialize(&(0 as u128))?);
         }
-        packed_header.extend(bincode::serialize(&(opt_header_len as u64))?);
+        packed_header.extend(bincode::serialize(&(opt_header_str.len() as u64))?);
 
         // Pack optional header
         let mut cipher = Rc4::new(&self.arc4_key);
-        let mut out_header: Vec<u8> = vec![0; opt_header_len];
-        cipher.process(self.opt_header.as_bytes(), &mut out_header[..]);
+        let mut out_header: Vec<u8> = vec![0; opt_header_str.len()];
+        cipher.process(opt_header_str.as_bytes(), &mut out_header[..]);
         packed_header.extend(out_header);
 
         Ok(packed_header)
     }
 }
 
-#[derive(Serialize, Deserialize)]
 struct CartFooter {
-    opt_footer: String,
+    opt_footer: JsonValue,
     opt_footer_pos: usize,
 }
 
 impl CartFooter {
-    fn new(opt_footer: Option<String>, opt_footer_pos: usize) -> CartFooter {
-        let opt_footer = match opt_footer {
-            Some(k) => k,
-            None => String::from(""),
-        };
+    fn new(opt_footer: Option<JsonValue>, opt_footer_pos: usize) -> CartFooter {
+        let opt_footer = opt_footer.unwrap_or(JsonValue::Null);
 
         CartFooter{opt_footer, opt_footer_pos}
     }
@@ -212,26 +206,26 @@ impl CartFooter {
         let mut cipher = Rc4::new(&arc4_key);
         let mut plain_text: Vec<u8> = vec![0; opt_footer_len as usize];
         cipher.process(&buffer, &mut plain_text[..]);
-        let opt_footer = str::from_utf8(&plain_text)?.to_string();
+        let opt_footer = json::parse(&str::from_utf8(&plain_text)?.to_string())?;
 
         Ok(CartFooter{opt_footer, opt_footer_pos})
     }
 
     fn pack(&self, arc4_key: &Vec<u8>) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         let mut packed_footer: Vec<u8> = Vec::new();
-        let opt_footer_len = self.opt_footer.len();
+        let opt_footer_str = self.opt_footer.dump();
 
         // Pack optional footer
         let mut cipher = Rc4::new(&arc4_key);
-        let mut out_footer: Vec<u8> = vec![0; opt_footer_len];
-        cipher.process(self.opt_footer.as_bytes(), &mut out_footer[..]);
+        let mut out_footer: Vec<u8> = vec![0; opt_footer_str.len()];
+        cipher.process(opt_footer_str.as_bytes(), &mut out_footer[..]);
         packed_footer.extend(out_footer);
 
         // Pack mandatory footer
         packed_footer.extend(globals::TRAC_MAGIC.as_bytes());
         packed_footer.extend(bincode::serialize(&(0 as u64))?);
         packed_footer.extend(bincode::serialize(&(self.opt_footer_pos as u64))?);
-        packed_footer.extend(bincode::serialize(&(opt_footer_len as u64))?);
+        packed_footer.extend(bincode::serialize(&(opt_footer_str.len() as u64))?);
 
         Ok(packed_footer)
     }

--- a/src/cartobj.rs
+++ b/src/cartobj.rs
@@ -143,7 +143,11 @@ impl CartHeader {
 
     fn pack(&self) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         let mut packed_header: Vec<u8> = Vec::new();
-        let opt_header_str = self.opt_header.dump();
+        let opt_header_str = if self.opt_header != JsonValue::Null {
+            self.opt_header.dump()
+        } else {
+            "".to_string()
+        };
 
         // Pack mandatory header
         packed_header.extend(self.magic.as_bytes());
@@ -213,7 +217,11 @@ impl CartFooter {
 
     fn pack(&self, arc4_key: &Vec<u8>) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         let mut packed_footer: Vec<u8> = Vec::new();
-        let opt_footer_str = self.opt_footer.dump();
+        let opt_footer_str = if self.opt_footer != JsonValue::Null {
+            self.opt_footer.dump()
+        } else {
+            "".to_string()
+        };
 
         // Pack optional footer
         let mut cipher = Rc4::new(&arc4_key);

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -1,5 +1,9 @@
 pub const DEFAULT_VERSION: i16 = 1; // TODO Dynamically generate this constant from cargo package
 pub const DEFAULT_ARC4_KEY: &[u8] = b"\x03\x01\x04\x01\x05\x09\x02\x06\x03\x01\x04\x01\x05\x09\x02\x06";
+
 pub const CART_MAGIC: &str = "CART";
 pub const TRAC_MAGIC: &str = "TRAC";
+
+pub const MAN_HEADER_LEN: u64 = 38;
+pub const MAN_FOOTER_LEN: u64 = 28;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,20 +1,15 @@
-extern crate bincode;
-extern crate crypto;
-extern crate libflate;
-extern crate json;
-
 mod globals;
 mod cartobj;
 
+use std::str;
+use std::fs::File;
+use std::path::Path;
+use std::io::{Read, Write, Seek};
+use json::JsonValue;
 use crypto::md5::Md5;
 use crypto::sha1::Sha1;
 use crypto::sha2::Sha256;
 use crypto::digest::Digest;
-use json::JsonValue;
-use std::io::{Read, Write, Seek};
-use std::fs::File;
-use std::path::Path;
-use std::str;
 
 pub fn pack(mut istream: impl Read, mut ostream: impl Write, opt_header: Option<JsonValue>,
 opt_footer: Option<JsonValue>, arc4_key: Option<Vec<u8>>) -> Result<(), Box<dyn std::error::Error>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod config;
 use std::process;
 use std::fs::{read_to_string, remove_file, write};
 use std::path::Path;
-use json::object;
+use json::JsonValue;
 
 fn main() {
     // Parse configuration variables
@@ -101,9 +101,7 @@ fn main() {
             }
         } else {
             // Generate default filename from input path
-            let mut metadata = object!{
-                name: i_path.file_name().unwrap().to_string_lossy().to_string()
-            };
+            let mut metadata = JsonValue::new_object();
 
             // Compile metadata from cartmeta file (simply carry on if there is no cartmeta file)
             let m_path = format!("{}.cartmeta", i_path.to_string_lossy());


### PR DESCRIPTION
Moves the metadata generation that is relative to the binary (hashes, length, name, etc) to the "pack_file" function. This means that it is possible for the "pack" to not produce any metadata, leaving the option for the user to generate a file with no metadata embedded. The library user can still generate it on their own and pass it as an opt_footer/opt_header argument, or use the "pack_file" method, which includes the metadata.