### PR TITLE
Ignore binary when extracting only metadata

### DIFF
--- a/src/cartobj.rs
+++ b/src/cartobj.rs
@@ -60,6 +60,23 @@ impl CartObject {
         Ok(CartObject{header, footer, binary})
     }
 
+    pub fn examine(mut cart_stream: impl Read+Seek, arc4_key: Option<Vec<u8>>)
+    -> Result<(JsonValue, JsonValue), Box<dyn std::error::Error>> {
+        let header_obj = CartHeader::unpack(&mut cart_stream, arc4_key)?;
+        let footer_obj = CartFooter::unpack(&mut cart_stream, &header_obj.arc4_key)?;
+
+        let header = match header_obj.opt_header {
+            Some(j) => j.clone(),
+            None => JsonValue::new_object(),
+        };
+        let footer = match footer_obj.opt_footer {
+            Some(j) => j.clone(),
+            None => JsonValue::new_object(),
+        };
+
+        Ok((header, footer))
+    }
+
     pub fn pack(&self) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         let mut packed_cart: Vec<u8> = Vec::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,7 @@ pub fn unpack(istream: impl Read+Seek, mut ostream: impl Write, arc4_key_overrid
 
 pub fn examine(i_stream: impl Read+Seek, arc4_key_override: Option<Vec<u8>>)
 -> Result<(JsonValue, JsonValue), Box<dyn std::error::Error>> {
-    let cart_obj = cartobj::CartObject::unpack(i_stream, arc4_key_override)?;
-
-    cart_obj.metadata()
+    cartobj::CartObject::examine(i_stream, arc4_key_override)
 }
 
 pub fn pack_file(i_path: &Path, o_path: &Path, opt_header: Option<JsonValue>, opt_footer: Option<JsonValue>,


### PR DESCRIPTION
Fixes #5. Up until this point, the whole binary would be read and processed, even when only looking at the CaRT metadata. This quick bugfix ensure that only the metadata is looked at by the "examine" function, limiting the opportunities where the entire binary is loaded in memory. 
This should increase both performance (removing computing time that is ultimately unnecessary) and security (avoiding loading potentially malicious code in memory unless explicitly told to do so). 