### PR TITLE
Return message instead of empty JSON data

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -153,7 +153,11 @@ fn main() {
 
             // Only show metadata if requested
             if params.showmeta {
-                println!("{}", metadata.pretty(4));
+                if metadata.is_empty() {
+                    println!("No metadata is associated with this file.");
+                } else {
+                    println!("{}", metadata.pretty(4));
+                }
                 continue;
             }
 


### PR DESCRIPTION
Fixes #13. The logic of the --showmeta was sound, but it was confusing that it returned an empty JSON when used with a file. The expected behaviour would either be to calculate on the fly the metadata (maybe not the most sensible idea), or to indicate to the user that not metadata file was found.